### PR TITLE
Fix parsing streets starting the same as number prefixes

### DIFF
--- a/src/AddressSplitter.php
+++ b/src/AddressSplitter.php
@@ -49,7 +49,9 @@ class AddressSplitter
      *
      * * assumes each alternative must either be at the start of the string or be preceded by whitespace,
      *
-     * * assumes each alternative to be case insensitive.
+     * * assumes each alternative to be case insensitive,
+     *
+     * * checks that the prefix will be succeeded by a number (following optional spaces).
      *
      * @param array $numberPrefixes a list of regular expressions (assuming 'x' and 'u' flags)
      * @return string a regular expression for an anonymous group matching the alternatives supplied in the argument
@@ -58,7 +60,7 @@ class AddressSplitter
     {
          return self::concatenateRegexAlternatives(array_map(
             function ($numberPrefix) {
-                return '(?: ^ | (?<=\s)) (?i: ' . $numberPrefix . ' )';
+                return '(?: ^ | (?<=\s)) (?i: ' . $numberPrefix . ' (?= \s* \pN+) )';
             },
             $numberPrefixes
         ));

--- a/tests/AddressSplitterTest.php
+++ b/tests/AddressSplitterTest.php
@@ -676,6 +676,123 @@ class AddressSplitterTest extends \PHPUnit_Framework_TestCase
                     'additionToAddress2' => 'WG Nr 13'
                 )
             ),
+            array(
+                'Norkshäuschen 8',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Norkshäuschen',
+                    'houseNumber'        => '8',
+                    'houseNumberParts'   => array(
+                        'base' => '8',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => ''
+                )
+            ),
+            array(
+                'No Street 8',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'No Street',
+                    'houseNumber'        => '8',
+                    'houseNumberParts'   => array(
+                        'base' => '8',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => ''
+                )
+            ),
+            array(
+                'No Street No 8',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'No Street',
+                    'houseNumber'        => '8',
+                    'houseNumberParts'   => array(
+                        'base' => '8',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => ''
+                )
+            ),
+            array(
+                'Acme Corporation, No Street No 8 c/o Chief Happiness Officer',
+                array(
+                    'additionToAddress1' => 'Acme Corporation',
+                    'streetName'         => 'No Street',
+                    'houseNumber'        => '8',
+                    'houseNumberParts'   => array(
+                        'base' => '8',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => 'c/o Chief Happiness Officer'
+                )
+            ),
+            array(
+                'Acme Corporation, No 800 North Street',
+                array(
+                    'additionToAddress1' => 'Acme Corporation',
+                    'streetName'         => 'North Street',
+                    'houseNumber'        => '800',
+                    'houseNumberParts'   => array(
+                        'base' => '800',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => ''
+                )
+            ),
+            array(
+                'Acme Corporation, No 800 Number Street',
+                array(
+                    'additionToAddress1' => 'Acme Corporation',
+                    'streetName'         => 'Number Street',
+                    'houseNumber'        => '800',
+                    'houseNumberParts'   => array(
+                        'base' => '800',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => ''
+                )
+            ),
+            array(
+                'Wegstraße 25 Hausnummer 23',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Wegstraße',
+                    'houseNumber'        => '25',
+                    'houseNumberParts'   => array(
+                        'base' => '25',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => 'Hausnummer 23'
+                )
+            ),
+            array(
+                '25 Roadstreet, APT Number 23',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Roadstreet',
+                    'houseNumber'        => '25',
+                    'houseNumberParts'   => array(
+                        'base' => '25',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => 'APT Number 23'
+                )
+            ),
+            array(
+                '25 Roadstreet, Hausnummer 23',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Roadstreet',
+                    'houseNumber'        => '25',
+                    'houseNumberParts'   => array(
+                        'base' => '25',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => 'Hausnummer 23'
+                )
+            ),
         );
     }
 


### PR DESCRIPTION
Resolves: <https://github.com/pickware/address-splitter/issues/30>